### PR TITLE
Drop references to Coveralls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,4 @@
 
 source 'https://rubygems.org'
 
-# coveralls fails on Ruby 1.9. My understanding is we don't need to run this on
-# more than one version anyway, so restrict to the current latest.
-version_pieces = RUBY_VERSION.split('.')
-major_version  = version_pieces[0]
-minor_version  = version_pieces[1]
-if major_version == '2' && minor_version == '7'
-  gem 'coveralls', require: false
-end
-
 gemspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,4 @@
 # frozen_string_literal: true
 
-# coveralls fails on Ruby 1.9. My understanding is we don't need to run this on
-# more than one version anyway, so restrict to the current latest.
-version_pieces = RUBY_VERSION.split('.')
-major_version  = version_pieces[0]
-minor_version  = version_pieces[1]
-if major_version == '2' && minor_version == '7'
-  require 'coveralls'
-  Coveralls.wear!
-end
-
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'minfraud'


### PR DESCRIPTION
As far as I can tell, this isn't currently working. It doesn't seem
useful enough to fix.