### PR TITLE
Fix warning from Faraday about basic_auth

### DIFF
--- a/lib/minfraud/http_service.rb
+++ b/lib/minfraud/http_service.rb
@@ -30,9 +30,13 @@ module Minfraud
       account_id = Minfraud.account_id
       account_id = Minfraud.user_id if account_id.nil?
 
-      builder.basic_auth account_id, Minfraud.license_key
+      if Faraday::VERSION.to_i.zero?
+        builder.basic_auth account_id, Minfraud.license_key
+      else
+        builder.request :basic_auth, account_id, Minfraud.license_key
+      end
 
-      builder.response   :json, content_type: /\bjson$/
+      builder.response :json, content_type: /\bjson$/
 
       builder.adapter :net_http_persistent, pool_size: 5 do |http|
         http.idle_timeout = 30


### PR DESCRIPTION
Newer versions of Faraday (like 1.8.0) issue a deprecation warning
when using Faraday::Connection#basic_auth.

This tweaks the Faraday middleware configuration to fix the warning,
while maintaining compatibility with Faraday versions below 1.x.

<details>
<summary>Faraday deprecation warning message</summary>

WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:basic_auth, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.

</details>