### PR TITLE
add ruby and http lib version to user agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Added the processor `:shopify_payments` to `Minfraud::Components::Payment`.
 * Added the processor `:google_pay` to `Minfraud::Components::Payment`.
 * Added the processor `:placetopay` to `Minfraud::Components::Payment`.
+* In addition to the minfraud gem version, the User-Agent now includes the
+  version of Ruby and the version of the HTTP client in all HTTP requests.
 
 ## v2.2.0 (2022-03-28)
 

--- a/lib/minfraud.rb
+++ b/lib/minfraud.rb
@@ -70,13 +70,14 @@ module Minfraud
 
     private
 
+
     def make_http_client
       HTTP.basic_auth(
         user: @account_id,
         pass: @license_key,
       ).headers(
         accept:     'application/json',
-        user_agent: "minfraud-api-ruby/#{Minfraud::VERSION}",
+        user_agent: "minfraud-api-ruby/#{Minfraud::VERSION} ruby/#{RUBY_VERSION} http/#{HTTP::VERSION}",
       )
     end
   end

--- a/lib/minfraud.rb
+++ b/lib/minfraud.rb
@@ -70,7 +70,6 @@ module Minfraud
 
     private
 
-
     def make_http_client
       HTTP.basic_auth(
         user: @account_id,


### PR DESCRIPTION
In addition to the minfraud gem version, the User-Agent now includes the version of Ruby and the version of the HTTP client in all HTTP requests.