### PR TITLE
Use 'GeoIP'/'GeoLite' branding in documentation

### DIFF
--- a/lib/minfraud/model/geoip2_location.rb
+++ b/lib/minfraud/model/geoip2_location.rb
@@ -4,7 +4,7 @@ require 'maxmind/geoip2/record/location'
 
 module Minfraud
   module Model
-    # Model of the GeoIP2 location information, including the local time.
+    # Model of the GeoIP location information, including the local time.
     class GeoIP2Location < MaxMind::GeoIP2::Record::Location
       # The date and time of the transaction in the time zone associated with
       # the IP address. The value is formatted according to RFC 3339. For

--- a/lib/minfraud/model/insights.rb
+++ b/lib/minfraud/model/insights.rb
@@ -43,7 +43,7 @@ module Minfraud
       # @return [Minfraud::Model::Email]
       attr_reader :email
 
-      # An object containing GeoIP2 and minFraud Insights information about the
+      # An object containing GeoIP and minFraud Insights information about the
       # geolocated IP address.
       #
       # @return [Minfraud::Model::IPAddress]

--- a/lib/minfraud/model/ip_address.rb
+++ b/lib/minfraud/model/ip_address.rb
@@ -6,7 +6,7 @@ require 'minfraud/model/ip_risk_reason'
 
 module Minfraud
   module Model
-    # Model containing GeoIP2 data and the risk for the IP address.
+    # Model containing GeoIP data and the risk for the IP address.
     class IPAddress < MaxMind::GeoIP2::Model::Insights
       # This field contains the risk associated with the IP address. The value
       # ranges from 0.01 to 99. A higher score indicates a higher risk.


### PR DESCRIPTION
Updates prose/documentation to refer to the products as "GeoIP"/"GeoLite" instead of "GeoIP2"/"GeoLite2". Technical identifiers (packages, class names, .mmdb filenames, edition IDs, the geolite.info hostname, URLs) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)